### PR TITLE
prepare for next dev cycle: update version to 0.1.0-SNAPSHOT

### DIFF
--- a/commands/bin/islandora.php
+++ b/commands/bin/islandora.php
@@ -33,7 +33,7 @@ try {
         $std_err->writeln("\n" . $event->getException()->getTraceAsString());
     });
 
-    $application = new Application('Islandora Command Tool', '0.0.1-SNAPSHOT');
+    $application = new Application('Islandora Command Tool', '0.1.0-SNAPSHOT');
     $application->setDispatcher($dispatcher);
 
     // A little magic to find all IslandoraCommand classes and dynamically

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>ca.islandora</groupId>
     <artifactId>islandora-parent</artifactId>
-    <version>0.0.1</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>ca.islandora.component</groupId>

--- a/indexing/islandora-indexing-triplestore/pom.xml
+++ b/indexing/islandora-indexing-triplestore/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ca.islandora</groupId>
     <artifactId>islandora-parent</artifactId>
-    <version>0.0.1</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/indexing/pom.xml
+++ b/indexing/pom.xml
@@ -6,7 +6,7 @@
   <parent>
       <groupId>ca.islandora</groupId>
       <artifactId>islandora-parent</artifactId>
-      <version>0.0.1</version>
+      <version>0.1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>ca.islandora</groupId>

--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ca.islandora</groupId>
     <artifactId>islandora-parent</artifactId>
-    <version>0.0.1</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>ca.islandora</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <groupId>ca.islandora</groupId>
   <artifactId>islandora-parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.0.1</version>
+  <version>0.1.0-SNAPSHOT</version>
   <url>http://islandora.ca/CLAW</url>
 
   <name>Islandora CLAW :: Parent POM</name>
@@ -435,7 +435,7 @@
     <connection>scm:git:git@github.com:Islandora-CLAW/Alpaca.git</connection>
     <developerConnection>scm:git:git@github.com:Islandora-CLAW/Alpaca.git</developerConnection>
     <url>https://github.com/islandora-claw/Alpaca</url>
-    <tag>islandora-parent-0.0.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <issueManagement>

--- a/sync/pom.xml
+++ b/sync/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>ca.islandora</groupId>
     <artifactId>islandora-parent</artifactId>
-    <version>0.0.1</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>ca.islandora.sync</groupId>


### PR DESCRIPTION
This updates the version of Alpaca to 0.1.0-SNAPSHOT

Note: I did not change the version to 0.0.2-SNAPSHOT because doing so implies that the version is _necessarily_ compatible with 0.0.1, which it may not be. At release time, if the release is really just a patch release (e.g. 0.0.2), then the maven plugin will allow you to set the version as such. If it isn't (at this stage, quite likely), then there is no implicit suggestion that the snapshot release is compatible. (I'd note that this is in line with what a lot of other Java-based OSS projects do)