### PR TITLE
Update Alpaca to use new JWT Authenication

### DIFF
--- a/islandora-indexing-triplestore/src/main/cfg/ca.islandora.alpaca.indexing.triplestore.cfg
+++ b/islandora-indexing-triplestore/src/main/cfg/ca.islandora.alpaca.indexing.triplestore.cfg
@@ -6,7 +6,3 @@ input.stream=activemq:queue:islandora-indexing-triplestore
 
 # The base URL of the triplestore being used.
 triplestore.baseUrl=http://localhost:8080/bigdata/namespace/kb/sparql
-
-# Credentials for user with read privileges for the resource.
-drupal.username=
-drupal.password=

--- a/islandora-indexing-triplestore/src/main/java/ca/islandora/alpaca/indexing/triplestore/TriplestoreIndexer.java
+++ b/islandora-indexing-triplestore/src/main/java/ca/islandora/alpaca/indexing/triplestore/TriplestoreIndexer.java
@@ -90,9 +90,8 @@ public class TriplestoreIndexer extends RouteBuilder {
         from("direct:retrieve.resource")
             .routeId("IslandoraTriplestoreIndexerRetrieveResource")
                 .setHeader(Exchange.HTTP_METHOD, constant("GET"))
-                .toD("${property.uri}?_format=jsonld&authUsername={{drupal.username}}" +
-                     "&authPassword={{drupal.password}}"
-                );
+                .setHeader("Authentication", simple("${headers['Authentication']}"))
+                .toD("${property.uri}?_format=jsonld");
 
         // Converts the resource to a SPARQL update query, POSTing it to the triplestore.
         from("direct:triplestore.index")

--- a/islandora-indexing-triplestore/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/islandora-indexing-triplestore/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -13,8 +13,6 @@
       <cm:property name="error.maxRedeliveries" value="5"/>
       <cm:property name="input.stream" value="activemq:queue:islandora-indexing-triplestore"/>
       <cm:property name="triplestore.baseUrl" value="http://localhost:8080/bigdata/namespace/kb/sparql"/>
-      <cm:property name="drupal.username" value=""/>
-      <cm:property name="drupal.password" value=""/>
     </cm:default-properties>
   </cm:property-placeholder>
 

--- a/islandora-indexing-triplestore/src/test/java/ca/islandora/alpaca/indexing/triplestore/TriplestoreIndexerTest.java
+++ b/islandora-indexing-triplestore/src/test/java/ca/islandora/alpaca/indexing/triplestore/TriplestoreIndexerTest.java
@@ -188,9 +188,11 @@ public class TriplestoreIndexerTest extends CamelBlueprintTestSupport {
 
         endpoint.expectedMessageCount(1);
         endpoint.expectedHeaderReceived(Exchange.HTTP_METHOD, "GET");
+        endpoint.expectedHeaderReceived("Authentication", "some_nifty_token");
 
         template.send(exchange -> {
             exchange.setProperty("uri", "http://localhost:8000/fedora_resource/1");
+            exchange.getIn().setHeader("Authentication", "some_nifty_token");
         });
 
         assertMockEndpointsSatisfied();

--- a/islandora-indexing-triplestore/src/test/resources/OSGI-INF/blueprint/blueprint-test.xml
+++ b/islandora-indexing-triplestore/src/test/resources/OSGI-INF/blueprint/blueprint-test.xml
@@ -13,8 +13,6 @@
       <cm:property name="error.maxRedeliveries" value="5"/>
       <cm:property name="input.stream" value="activemq:queue:islandora-indexing-triplestore"/>
       <cm:property name="triplestore.baseUrl" value="http://localhost:8080/bigdata/namespace/kb/sparql"/>
-      <cm:property name="drupal.username" value=""/>
-      <cm:property name="drupal.password" value=""/>
       <cm:property name="jms.brokerUrl" value="tcp://localhost:61616"/>
     </cm:default-properties>
   </cm:property-placeholder>


### PR DESCRIPTION
Remove the old hardcoded drupal username and password and instead rely
on the JWT token passed in the message to provide drupal authentication.

Part of:
https://github.com/Islandora-CLAW/CLAW/issues/520