### PR TITLE
First draft of a simple auth-aware HttpClient service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 workbench.xmi
 target
 build
+.DS_Store
+bin/

--- a/build.gradle
+++ b/build.gradle
@@ -87,8 +87,7 @@ subprojects {
     checkstyle {
         configFile = rootProject.file('gradle/checkstyle/checkstyle.xml')
         configProperties.checkstyleConfigDir = rootProject.file('gradle/checkstyle')
-        /* eventually, we should change this to fail builds on errors */
-        ignoreFailures true
+        ignoreFailures false
     }
 
     license {

--- a/islandora-http-client/build.gradle
+++ b/islandora-http-client/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'osgi'
 description = 'Islandora CLAW HTTP Client'
 
 dependencies {
-    compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'
+    compile group: 'org.apache.httpcomponents', name: 'httpclient-osgi', version: '4.5.3'
 
     testCompile group: 'junit', name: 'junit', version:'4.12'
 }
@@ -15,8 +15,13 @@ jar {
       vendor project.vendor
       license project.license
 
-      instruction 'Import-Package', 'org.apache.http.client,' +
-                            defaultOsgiImports
+      instruction 'Import-Package',
+        'org.apache.http,' + 
+        'org.apache.http.protocol,' +
+        'org.apache.http.message,' +
+        'org.apache.http.impl.client,' + 
+        'org.apache.http.client,' +
+        defaultOsgiImports
       instruction 'Export-Package', 'ca.islandora.alpaca.http.client'
     }
 }

--- a/islandora-http-client/build.gradle
+++ b/islandora-http-client/build.gradle
@@ -1,0 +1,29 @@
+apply plugin: 'osgi'
+
+description = 'Islandora CLAW HTTP Client'
+
+dependencies {
+    compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'
+
+    testCompile group: 'junit', name: 'junit', version:'4.12'
+}
+
+jar {
+    manifest {
+      description project.description
+      docURL project.docURL
+      vendor project.vendor
+      license project.license
+
+      instruction 'Import-Package', 'org.apache.http.client,' +
+                            defaultOsgiImports
+      instruction 'Export-Package', 'ca.islandora.indexing.http.client'
+    }
+}
+
+artifacts {
+    archives (file('build/cfg/main/ca.islandora.alpaca.http.client.cfg')) {
+        classifier 'configuration'
+        type 'cfg'
+    }
+}

--- a/islandora-http-client/build.gradle
+++ b/islandora-http-client/build.gradle
@@ -17,7 +17,7 @@ jar {
 
       instruction 'Import-Package', 'org.apache.http.client,' +
                             defaultOsgiImports
-      instruction 'Export-Package', 'ca.islandora.indexing.http.client'
+      instruction 'Export-Package', 'ca.islandora.alpaca.http.client'
     }
 }
 

--- a/islandora-http-client/src/main/cfg/ca.islandora.alpaca.http.client.cfg
+++ b/islandora-http-client/src/main/cfg/ca.islandora.alpaca.http.client.cfg
@@ -1,0 +1,3 @@
+# The static token value to be used for authentication by the HttpClient available as an OSGi service for
+# other services to use against the Fedora repository
+token.value=islandora

--- a/islandora-http-client/src/main/java/ca/islandora/alpaca/http/client/StaticTokenRequestInterceptor.java
+++ b/islandora-http-client/src/main/java/ca/islandora/alpaca/http/client/StaticTokenRequestInterceptor.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Islandora Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Islandora Foundation licenses this file to you under the MIT License.
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.islandora.alpaca.http.client;
+
+import static java.util.Objects.requireNonNull;
+
+import org.apache.http.Header;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.protocol.HttpContext;
+
+public class StaticTokenRequestInterceptor implements HttpRequestInterceptor {
+
+	public static final String AUTH_HEADER = "Authorization";
+
+	private Header header;
+
+	public StaticTokenRequestInterceptor() {
+	}
+
+	public StaticTokenRequestInterceptor(String token) {
+		this.header = makeHeader(token);
+	}
+
+	public void setToken(String token) {
+		this.header = makeHeader(token);
+	}
+
+	private Header makeHeader(String token) {
+		return new BasicHeader(AUTH_HEADER, "Bearer " + requireNonNull(token, "Token must not be null!"));
+	}
+
+	@Override
+	public void process(HttpRequest request, HttpContext context) {
+		// we do not inject if auth headers present
+		if (request.getFirstHeader(AUTH_HEADER)== null) request.addHeader(header);
+	}
+	
+	public static HttpClient defaultClient(StaticTokenRequestInterceptor interceptor) {
+		return HttpClientBuilder.create().addInterceptorFirst(interceptor).build();
+	}
+}

--- a/islandora-http-client/src/main/java/ca/islandora/alpaca/http/client/StaticTokenRequestInterceptor.java
+++ b/islandora-http-client/src/main/java/ca/islandora/alpaca/http/client/StaticTokenRequestInterceptor.java
@@ -28,34 +28,58 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.protocol.HttpContext;
 
+/**
+ * Adds a single authentication header to any request that does not
+ * already have at least one authentication header.
+ * 
+ * @author ajs6f
+ *
+ */
 public class StaticTokenRequestInterceptor implements HttpRequestInterceptor {
 
-	public static final String AUTH_HEADER = "Authorization";
+    public static final String AUTH_HEADER = "Authorization";
 
-	private Header header;
+    private Header header;
 
-	public StaticTokenRequestInterceptor() {
-	}
+    /**
+     * Default constructor
+     */
+    public StaticTokenRequestInterceptor() {
+    }
 
-	public StaticTokenRequestInterceptor(String token) {
-		this.header = makeHeader(token);
-	}
+    /**
+     * @param token the authentication token to use
+     */
+    public StaticTokenRequestInterceptor(final String token) {
+        this.header = makeHeader(token);
+    }
 
-	public void setToken(String token) {
-		this.header = makeHeader(token);
-	}
+    /**
+     * @param token the authentication token to use
+     */
+    public void setToken(final String token) {
+        this.header = makeHeader(token);
+    }
 
-	private Header makeHeader(String token) {
-		return new BasicHeader(AUTH_HEADER, "Bearer " + requireNonNull(token, "Token must not be null!"));
-	}
+    private static Header makeHeader(final String token) {
+        return new BasicHeader(AUTH_HEADER, "Bearer " + requireNonNull(token, "Token must not be null!"));
+    }
 
-	@Override
-	public void process(HttpRequest request, HttpContext context) {
-		// we do not inject if auth headers present
-		if (request.getFirstHeader(AUTH_HEADER)== null) request.addHeader(header);
-	}
-	
-	public static HttpClient defaultClient(StaticTokenRequestInterceptor interceptor) {
-		return HttpClientBuilder.create().addInterceptorFirst(interceptor).build();
-	}
+    @Override
+    public void process(final HttpRequest request, final HttpContext context) {
+        // we do not inject if auth headers present
+        if (request.getFirstHeader(AUTH_HEADER) == null) {
+            request.addHeader(header);
+        }
+    }
+
+    /**
+     * Convenience factory method.
+     * 
+     * @param interceptor
+     * @return a default-configuration {@link HttpClient} that is wrapped with this interceptor
+     */
+    public static HttpClient defaultClient(final StaticTokenRequestInterceptor interceptor) {
+        return HttpClientBuilder.create().addInterceptorFirst(interceptor).build();
+    }
 }

--- a/islandora-http-client/src/main/java/ca/islandora/alpaca/http/client/StaticTokenRequestInterceptor.java
+++ b/islandora-http-client/src/main/java/ca/islandora/alpaca/http/client/StaticTokenRequestInterceptor.java
@@ -76,7 +76,7 @@ public class StaticTokenRequestInterceptor implements HttpRequestInterceptor {
     /**
      * Convenience factory method.
      * 
-     * @param interceptor
+     * @param interceptor the interceptor to use, presumably an instance of {@link StaticTokenRequestInterceptor}
      * @return a default-configuration {@link HttpClient} that is wrapped with this interceptor
      */
     public static HttpClient defaultClient(final StaticTokenRequestInterceptor interceptor) {

--- a/islandora-http-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/islandora-http-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+       xsi:schemaLocation="
+       http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0 http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
+       http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+  <!-- OSGI blueprint property placeholder -->
+  <cm:property-placeholder id="properties" persistent-id="ca.islandora.alpaca.http.client" update-strategy="reload" >
+    <cm:default-properties>
+      <cm:property name="token.value" value="islandora"/>
+    </cm:default-properties>
+  </cm:property-placeholder>
+  
+  <service id="httpClient" interface="org.apache.http.client.HttpClient" filter="(osgi.jndi.service.name=claw/httpClient)">
+    <bean class="ca.islandora.alpaca.http.client.StaticTokenRequestInterceptor" factory-method=“defaultClient”>
+      <argument>
+        <bean id="interceptor" class="ca.islandora.alpaca.http.client.StaticTokenRequestInterceptor">
+  	      <property name="token" value="${token.value}"/>
+        </bean>
+      </argument>
+    </bean>
+  </service>
+
+</blueprint>

--- a/islandora-http-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/islandora-http-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -13,10 +13,13 @@
     </cm:default-properties>
   </cm:property-placeholder>
   
-  <service id="httpClient" interface="org.apache.http.client.HttpClient" filter="(osgi.jndi.service.name=claw/httpClient)">
-    <bean class="ca.islandora.alpaca.http.client.StaticTokenRequestInterceptor" factory-method=“defaultClient”>
+  <service id="httpClient" interface="org.apache.http.client.HttpClient">
+    <service-properties>
+      <entry key="osgi.jndi.service.name" value="claw/httpClient"/>
+    </service-properties>
+    <bean class="ca.islandora.alpaca.http.client.StaticTokenRequestInterceptor" factory-method="defaultClient">
       <argument>
-        <bean id="interceptor" class="ca.islandora.alpaca.http.client.StaticTokenRequestInterceptor">
+        <bean class="ca.islandora.alpaca.http.client.StaticTokenRequestInterceptor">
   	      <property name="token" value="${token.value}"/>
         </bean>
       </argument>

--- a/islandora-http-client/src/test/java/ca/islandora/alpaca/http/client/StaticTokenRequestInterceptorTest.java
+++ b/islandora-http-client/src/test/java/ca/islandora/alpaca/http/client/StaticTokenRequestInterceptorTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Islandora Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Islandora Foundation licenses this file to you under the MIT License.
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.islandora.alpaca.http.client;
+
+import static ca.islandora.alpaca.http.client.StaticTokenRequestInterceptor.AUTH_HEADER;
+
+import org.apache.http.Header;
+import org.apache.http.HttpRequest;
+import org.apache.http.client.methods.HttpGet;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StaticTokenRequestInterceptorTest extends Assert {
+
+	@Test
+	public void shouldInjectHeaderWhenNoAuthHeadersPresent() {
+		StaticTokenRequestInterceptor testInterceptor = new StaticTokenRequestInterceptor("testToken");
+		HttpRequest request = new HttpGet();
+		testInterceptor.process(request, null);
+		Header[] authHeaders = request.getHeaders(AUTH_HEADER);
+		assertEquals("Should only be one auth header!", 1, authHeaders.length);
+		assertEquals("Wrong value for header!", "Bearer testToken", authHeaders[0].getValue());
+	}
+
+	@Test
+	public void shouldNotInjectHeaderWhenAuthHeadersPresent() {
+		StaticTokenRequestInterceptor testInterceptor = new StaticTokenRequestInterceptor("testToken");
+		HttpRequest request = new HttpGet();
+		request.addHeader(AUTH_HEADER, "fake header");
+		testInterceptor.process(request, null);
+		Header[] authHeaders = request.getHeaders(AUTH_HEADER);
+		assertEquals("Should only be one auth header!", 1, authHeaders.length);
+		assertEquals("Wrong value for header!", "fake header", authHeaders[0].getValue());
+	}
+}

--- a/islandora-http-client/src/test/java/ca/islandora/alpaca/http/client/StaticTokenRequestInterceptorTest.java
+++ b/islandora-http-client/src/test/java/ca/islandora/alpaca/http/client/StaticTokenRequestInterceptorTest.java
@@ -40,7 +40,8 @@ public class StaticTokenRequestInterceptorTest extends Assert {
 
 	@Test
 	public void shouldNotInjectHeaderWhenAuthHeadersPresent() {
-		StaticTokenRequestInterceptor testInterceptor = new StaticTokenRequestInterceptor("testToken");
+		StaticTokenRequestInterceptor testInterceptor = new StaticTokenRequestInterceptor();
+		testInterceptor.setToken("testToken");
 		HttpRequest request = new HttpGet();
 		request.addHeader(AUTH_HEADER, "fake header");
 		testInterceptor.process(request, null);

--- a/islandora-http-client/src/test/java/ca/islandora/alpaca/http/client/StaticTokenRequestInterceptorTest.java
+++ b/islandora-http-client/src/test/java/ca/islandora/alpaca/http/client/StaticTokenRequestInterceptorTest.java
@@ -26,27 +26,31 @@ import org.apache.http.client.methods.HttpGet;
 import org.junit.Assert;
 import org.junit.Test;
 
+/**
+ * @author ajs6f
+ *
+ */
 public class StaticTokenRequestInterceptorTest extends Assert {
 
-	@Test
-	public void shouldInjectHeaderWhenNoAuthHeadersPresent() {
-		StaticTokenRequestInterceptor testInterceptor = new StaticTokenRequestInterceptor("testToken");
-		HttpRequest request = new HttpGet();
-		testInterceptor.process(request, null);
-		Header[] authHeaders = request.getHeaders(AUTH_HEADER);
-		assertEquals("Should only be one auth header!", 1, authHeaders.length);
-		assertEquals("Wrong value for header!", "Bearer testToken", authHeaders[0].getValue());
-	}
+    @Test
+    public void shouldInjectHeaderWhenNoAuthHeadersPresent() {
+        final StaticTokenRequestInterceptor testInterceptor = new StaticTokenRequestInterceptor("testToken");
+        final HttpRequest request = new HttpGet();
+        testInterceptor.process(request, null);
+        final Header[] authHeaders = request.getHeaders(AUTH_HEADER);
+        assertEquals("Should only be one auth header!", 1, authHeaders.length);
+        assertEquals("Wrong value for header!", "Bearer testToken", authHeaders[0].getValue());
+    }
 
-	@Test
-	public void shouldNotInjectHeaderWhenAuthHeadersPresent() {
-		StaticTokenRequestInterceptor testInterceptor = new StaticTokenRequestInterceptor();
-		testInterceptor.setToken("testToken");
-		HttpRequest request = new HttpGet();
-		request.addHeader(AUTH_HEADER, "fake header");
-		testInterceptor.process(request, null);
-		Header[] authHeaders = request.getHeaders(AUTH_HEADER);
-		assertEquals("Should only be one auth header!", 1, authHeaders.length);
-		assertEquals("Wrong value for header!", "fake header", authHeaders[0].getValue());
-	}
+    @Test
+    public void shouldNotInjectHeaderWhenAuthHeadersPresent() {
+        final StaticTokenRequestInterceptor testInterceptor = new StaticTokenRequestInterceptor();
+        testInterceptor.setToken("testToken");
+        final HttpRequest request = new HttpGet();
+        request.addHeader(AUTH_HEADER, "fake header");
+        testInterceptor.process(request, null);
+        final Header[] authHeaders = request.getHeaders(AUTH_HEADER);
+        assertEquals("Should only be one auth header!", 1, authHeaders.length);
+        assertEquals("Wrong value for header!", "fake header", authHeaders[0].getValue());
+    }
 }

--- a/karaf/src/main/resources/features.xml
+++ b/karaf/src/main/resources/features.xml
@@ -30,5 +30,15 @@
     <configfile finalname="/etc/ca.islandora.alpaca.connector.broadcast.cfg">mvn:ca.islandora.alpaca/islandora-connector-broadcast/${project.version}/cfg/configuration</configfile>
 
   </feature>
+  
+  <feature name="islandora-http-client" version="${project.version}" start-level="80">
+  
+    <bundle dependency='true'>mvn:org.apache.httpcomponents/httpcore-osgi/4.4.6</bundle>
+    <bundle>mvn:org.apache.httpcomponents/httpclient-osgi/4.5.3</bundle>
+    <bundle>mvn:ca.islandora.alpaca/islandora-http-client/${project.version}</bundle>
+
+    <configfile finalname="/etc/ca.islandora.alpaca.http.client.cfg">mvn:ca.islandora.alpaca/islandora-http-client/${project.version}/cfg/configuration</configfile>
+  
+  </feature>
 
 </features>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,9 @@
 include ':islandora-karaf'
 include ':islandora-indexing-triplestore'
 include ':islandora-connector-broadcast'
+include ':islandora-http-client'
 
 project(':islandora-karaf').projectDir = "$rootDir/karaf" as File
 project(':islandora-indexing-triplestore').projectDir = "$rootDir/islandora-indexing-triplestore" as File
 project(':islandora-connector-broadcast').projectDir = "$rootDir/islandora-connector-broadcast" as File
+project(':islandora-http-client').projectDir = "$rootDir/islandora-http-client" as File


### PR DESCRIPTION
NOT FOR IMMEDIATE MERGE

**Add API-X to vagrant install**: (https://github.com/Islandora-CLAW/CLAW/issues/504)

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)

https://github.com/fcrepo4-labs/fcrepo-api-x/issues/112

# What does this Pull Request do?

This PR adds an `HttpClient` to the OSGi service registry that uses a configurable but static token to try to authenticate to its server. The intended "user" of this service is API-X, which needs to be able to act with authentication against a Syn-protected Fedora repository to install its own configuration.

# What's new?

There is now an authenticating client as described above available in the OSGi service registry.

# How should this be tested?

This PR will only be useful once API-X is modified to accept an authenticating client for use setting up its configuration. @birkland is willing to work on that problem.


# Interested parties

@dhlamb @birkland @jonathangreen @whikloj 