### PR TITLE
Issue 686

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,14 +44,12 @@ subprojects {
         docURL = 'http://github.com/Islandora-CLAW/wiki'
         license = 'MIT'
 
-        camelVersion = '2.18.1'
+        camelVersion = '2.19.2'
         slf4jVersion = '1.7.12'
         fcrepoCamelVersion = '4.5.0'
-        fcrepoCamelToolboxVersion = '4.7.0'
-        activemqVersion = '5.14.1'
+        fcrepoCamelToolboxVersion = '4.7.2'
+        activemqVersion = '5.15.0'
         commonsIoVersion = '2.4'
-
-        camelVersionRange = '[2.18.0, 3)'
 
         /* OSGi */
         defaultOsgiImports = 'org.osgi.service.blueprint;version="[1,2)",*'

--- a/islandora-connector-broadcast/build.gradle
+++ b/islandora-connector-broadcast/build.gradle
@@ -18,7 +18,7 @@ jar {
         license project.license
 
         instruction 'Import-Package', 'org.apache.activemq.camel.component,' +
-                            "org.apache.camel;version=\"${camelVersionRange}\"," +
+                            "org.apache.camel;version=\"${camelVersion}\"," +
                             defaultOsgiImports
         instruction 'Export-Package', 'ca.islandora.alpaca.connector.broadcast'
     }

--- a/islandora-indexing-fcrepo/build.gradle
+++ b/islandora-indexing-fcrepo/build.gradle
@@ -23,7 +23,7 @@ jar {
       license project.license
 
       instruction 'Import-Package', 'org.apache.camel.component.http4,' +
-                            "org.apache.camel;version=\"${camelVersionRange}\"," +
+                            "org.apache.camel;version=\"${camelVersion}\"," +
                             "org.apache.activemq.camel.component;version=\"${activemqVersion}\"," +
                             defaultOsgiImports
       instruction 'Export-Package', 'ca.islandora.indexing.fcrepo'

--- a/islandora-indexing-triplestore/build.gradle
+++ b/islandora-indexing-triplestore/build.gradle
@@ -25,7 +25,7 @@ jar {
       license project.license
 
       instruction 'Import-Package', 'org.apache.camel.component.http4,' +
-                            "org.apache.camel;version=\"${camelVersionRange}\"," +
+                            "org.apache.camel;version=\"${camelVersion}\"," +
                             "org.fcrepo.camel.processor," +
                             defaultOsgiImports
       instruction 'Export-Package', 'ca.islandora.indexing.triplestore'

--- a/islandora-indexing-triplestore/src/test/java/ca/islandora/alpaca/indexing/triplestore/TriplestoreIndexerTest.java
+++ b/islandora-indexing-triplestore/src/test/java/ca/islandora/alpaca/indexing/triplestore/TriplestoreIndexerTest.java
@@ -112,7 +112,6 @@ public class TriplestoreIndexerTest extends CamelBlueprintTestSupport {
             @Override
             public void configure() throws Exception {
                 replaceFromWith("direct:start");
-                mockEndpointsAndSkip("*");
             }
         });
         context.start();


### PR DESCRIPTION
**GitHub Issue**: Islandora-CLAW/CLAW#686

This will also affect https://github.com/Islandora-Devops/claw-playbook/pull/13

# What does this Pull Request do?

Bumps activemq, camel, and toolbox versions.  No longer relying on ranges.  This puts us in line with the SNAPSHOT builds of Api-X that we're using.

# How should this be tested?

Change https://github.com/Islandora-CLAW/claw_vagrant/blob/master/scripts/alpaca.sh#L12 to `git clone -b issue-686 https://github.com/dannylamb/Alpaca.git` and then `vagrant up`.  Alpaca and Api-X should get brought up properly, and Fedora syncing should be happening.

# Interested parties
@Natkeeran @MarcusBarnes @Islandora-CLAW/committers