### PR TITLE
Add code analysis plugins into build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ subprojects {
     apply plugin: 'signing'
     apply plugin: 'checkstyle'
     apply plugin: 'com.github.hierynomus.license'
+    apply plugin: 'pmd'
+    apply plugin: 'findbugs'
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
@@ -95,6 +97,23 @@ subprojects {
         header rootProject.file('gradle/license/header.txt')
         mapping {
             java = 'SLASHSTAR_STYLE'
+        }
+    }
+
+    pmd {
+        ignoreFailures true
+        ruleSetFiles = rootProject.files('gradle/pmd/ruleset.xml')
+    }
+    
+    findbugs {
+        ignoreFailures = true
+        effort = 'max'
+    }
+    
+    tasks.withType(FindBugs) {
+        reports {
+            xml.enabled false
+            html.enabled true
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,6 @@ subprojects {
     apply plugin: 'checkstyle'
     apply plugin: 'com.github.hierynomus.license'
     apply plugin: 'pmd'
-    apply plugin: 'findbugs'
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
@@ -103,18 +102,6 @@ subprojects {
     pmd {
         ignoreFailures true
         ruleSetFiles = rootProject.files('gradle/pmd/ruleset.xml')
-    }
-    
-    findbugs {
-        ignoreFailures = true
-        effort = 'max'
-    }
-    
-    tasks.withType(FindBugs) {
-        reports {
-            xml.enabled false
-            html.enabled true
-        }
     }
 
     publishing {

--- a/gradle/pmd/ruleset.xml
+++ b/gradle/pmd/ruleset.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<ruleset name="CLAW Alpaca PMD ruleset"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+
+  <description>
+  CLAW Alpaca PMD ruleset
+  </description>
+
+  <rule ref="rulesets/java/basic.xml"/>
+  <rule ref="rulesets/java/braces.xml"/>
+  <rule ref="rulesets/java/clone.xml"/>
+  <rule ref="rulesets/java/codesize.xml"/>
+  <rule ref="rulesets/java/comments.xml"/>
+  <rule ref="rulesets/java/controversial.xml"/>
+  <rule ref="rulesets/java/coupling.xml"/>
+  <rule ref="rulesets/java/design.xml"/>
+  <rule ref="rulesets/java/empty.xml"/>
+  <rule ref="rulesets/java/finalizers.xml"/>
+  <rule ref="rulesets/java/imports.xml"/>
+  <rule ref="rulesets/java/j2ee.xml"/>
+  <rule ref="rulesets/java/javabeans.xml"/>
+  <rule ref="rulesets/java/junit.xml"/>
+  <rule ref="rulesets/java/naming.xml"/>
+  <rule ref="rulesets/java/optimizations.xml"/>
+  <rule ref="rulesets/java/strictexception.xml"/>
+  <rule ref="rulesets/java/strings.xml"/>
+  <rule ref="rulesets/java/sunsecure.xml"/>
+  <rule ref="rulesets/java/typeresolution.xml"/>
+  <rule ref="rulesets/java/unnecessary.xml"/>
+  <rule ref="rulesets/java/unusedcode.xml"/>
+
+</ruleset>


### PR DESCRIPTION
**Alpaca gear up**: (https://github.com/Islandora-CLAW/CLAW/issues/725)

# What does this Pull Request do?

Adds two code analysis plugins, Findbugs and PMD, into Alpaca's build, producing HTML reports without ever blocking or failing the build.

# What's new?

Some stanzas in `build.gradle` and a file containing config for PMD.

# How should this be tested?

Do a build, see some advice on where/how code can be improved in various folders in `build/reports`. No functional changes should appear.

# Interested parties
@Islandora-CLAW/committers