### PR TITLE
updating travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ![Alpaca](https://cloud.githubusercontent.com/assets/2371345/15409648/16c140b4-1dec-11e6-81d9-41929bc83b1f.png) Alpaca
-[![Build Status](https://travis-ci.org/Islandora-CLAW/Alpaca.svg?branch=master)](https://travis-ci.org/Islandora-CLAW/Alpaca)
+[![Build Status](https://travis-ci.com/Islandora-CLAW/Alpaca.svg?branch=master)](https://travis-ci.com/Islandora-CLAW/Alpaca)
 [![Contribution Guidelines](http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg)](./CONTRIBUTING.md)
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](./LICENSE)
 [![codecov](https://codecov.io/gh/Islandora-CLAW/Alpaca/branch/master/graph/badge.svg)](https://codecov.io/gh/Islandora-CLAW/Alpaca)


### PR DESCRIPTION
**GitHub Issue**: Islandora-CLAW/CLAW#950

# What does this Pull Request do?

Grabs the travis badge from travis-ci.com instead of travis-ci.org

# Interested parties
@Islandora-CLAW/committers 

_Please delete the branch after merging_