### PR TITLE
Adding connection close to http4 endpoints

### DIFF
--- a/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeConnector.java
+++ b/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeConnector.java
@@ -63,13 +63,13 @@ public class DerivativeConnector extends RouteBuilder {
             .setHeader("X-Islandora-Args", simple("${exchangeProperty.event.attachment.content.args}"))
             .setHeader("Apix-Ldp-Resource", simple("${exchangeProperty.event.attachment.content.sourceUri}"))
             .setBody(simple("${null}"))
-            .to("{{derivative.service.url}}")
+            .to("{{derivative.service.url}}?connectionClose=true")
 
             // PUT the media.
             .removeHeaders("*", "Authorization", "Content-Type")
             .setHeader("Content-Location", simple("${exchangeProperty.event.attachment.content.fileUploadUri}"))
             .setHeader(Exchange.HTTP_METHOD, constant("PUT"))
-            .toD("${exchangeProperty.event.attachment.content.destinationUri}");
+            .toD("${exchangeProperty.event.attachment.content.destinationUri}?connectionClose=true");
     }
 
 }

--- a/islandora-connector-derivative/src/test/java/ca/islandora/alpaca/connector/derivative/DerivativeConnectorTest.java
+++ b/islandora-connector-derivative/src/test/java/ca/islandora/alpaca/connector/derivative/DerivativeConnectorTest.java
@@ -66,7 +66,7 @@ public class DerivativeConnectorTest extends CamelBlueprintTestSupport {
                     replaceFromWith("direct:start");
 
                     // Rig Drupal REST endpoint to return canned jsonld
-                    interceptSendToEndpoint("http://example.org/derivative/convert")
+                    interceptSendToEndpoint("http://example.org/derivative/convert?connectionClose=true")
                             .skipSendToOriginalEndpoint()
                             .process(exchange -> {
                                 exchange.getIn().removeHeaders("*", "Authorization");
@@ -74,7 +74,7 @@ public class DerivativeConnectorTest extends CamelBlueprintTestSupport {
                                 exchange.getIn().setBody("SOME DERIVATIVE", String.class);
                             });
 
-                    mockEndpointsAndSkip("http://localhost:8000/node/2/media/image/3");
+                    mockEndpointsAndSkip("http://localhost:8000/node/2/media/image/3?connectionClose=true");
                 }
         });
         context.start();

--- a/islandora-indexing-fcrepo/src/main/java/ca/islandora/alpaca/indexing/fcrepo/FcrepoIndexer.java
+++ b/islandora-indexing-fcrepo/src/main/java/ca/islandora/alpaca/indexing/fcrepo/FcrepoIndexer.java
@@ -137,7 +137,7 @@ public class FcrepoIndexer extends RouteBuilder {
                 .setBody(simple("${null}"))
 
                 // Pass it to milliner.
-                .toD(getMillinerBaseUrl() + "node/${exchangeProperty.uuid}");
+                .toD(getMillinerBaseUrl() + "node/${exchangeProperty.uuid}?connectionClose=true");
 
         from("{{node.delete.stream}}")
                 .routeId("FcrepoIndexerDeleteNode")
@@ -164,7 +164,7 @@ public class FcrepoIndexer extends RouteBuilder {
                 .setBody(simple("${null}"))
 
                 // Remove the file from Gemini.
-                .toD(getMillinerBaseUrl() + "node/${exchangeProperty.uuid}");
+                .toD(getMillinerBaseUrl() + "node/${exchangeProperty.uuid}?connectionClose=true");
 
         from("{{media.stream}}")
                 .routeId("FcrepoIndexerMedia")
@@ -184,7 +184,7 @@ public class FcrepoIndexer extends RouteBuilder {
                 .setBody(simple("${null}"))
 
                 // Pass it to milliner.
-                .toD(getMillinerBaseUrl() + "media/${exchangeProperty.sourceField}");
+                .toD(getMillinerBaseUrl() + "media/${exchangeProperty.sourceField}?connectionClose=true");
 
         from("{{file.stream}}")
                 .routeId("FcrepoIndexerFile")
@@ -207,7 +207,7 @@ public class FcrepoIndexer extends RouteBuilder {
                 )
 
                 // Index the file in Gemini.
-                .toD(getGeminiBaseUrl() + "${exchangeProperty.uuid}");
+                .toD(getGeminiBaseUrl() + "${exchangeProperty.uuid}?connectionClose=true");
 
         from("{{file.delete.stream}}")
                 .routeId("FcrepoIndexerFileDelete")
@@ -225,7 +225,7 @@ public class FcrepoIndexer extends RouteBuilder {
                 .setBody(simple("${null}"))
 
                 // Remove the file from Gemini.
-                .toD(getGeminiBaseUrl() + "${exchangeProperty.uuid}");
+                .toD(getGeminiBaseUrl() + "${exchangeProperty.uuid}?connectionClose=true");
 
     }
 }

--- a/islandora-indexing-fcrepo/src/test/java/ca/islandora/alpaca/indexing/fcrepo/FcrepoIndexerTest.java
+++ b/islandora-indexing-fcrepo/src/test/java/ca/islandora/alpaca/indexing/fcrepo/FcrepoIndexerTest.java
@@ -59,7 +59,9 @@ public class FcrepoIndexerTest extends CamelBlueprintTestSupport {
             @Override
             public void configure() throws Exception {
                 replaceFromWith("direct:start");
-                mockEndpointsAndSkip("http://localhost:8000/milliner/node/72358916-51e9-4712-b756-4b0404c91b1d");
+                mockEndpointsAndSkip(
+                    "http://localhost:8000/milliner/node/72358916-51e9-4712-b756-4b0404c91b1d?connectionClose=true"
+                );
             }
         });
         context.start();
@@ -92,7 +94,9 @@ public class FcrepoIndexerTest extends CamelBlueprintTestSupport {
             @Override
             public void configure() throws Exception {
                 replaceFromWith("direct:start");
-                mockEndpointsAndSkip("http://localhost:8000/milliner/node/72358916-51e9-4712-b756-4b0404c91b1d");
+                mockEndpointsAndSkip(
+                    "http://localhost:8000/milliner/node/72358916-51e9-4712-b756-4b0404c91b1d?connectionClose=true"
+                );
             }
         });
         context.start();
@@ -124,7 +128,9 @@ public class FcrepoIndexerTest extends CamelBlueprintTestSupport {
             @Override
             public void configure() throws Exception {
                 replaceFromWith("direct:start");
-                mockEndpointsAndSkip("http://localhost:8000/gemini/148dfe8f-9711-4263-97e7-3ef3fb15864f");
+                mockEndpointsAndSkip(
+                    "http://localhost:8000/gemini/148dfe8f-9711-4263-97e7-3ef3fb15864f?connectionClose=true"
+                );
             }
         });
         context.start();
@@ -161,7 +167,9 @@ public class FcrepoIndexerTest extends CamelBlueprintTestSupport {
             @Override
             public void configure() throws Exception {
                 replaceFromWith("direct:start");
-                mockEndpointsAndSkip("http://localhost:8000/gemini/148dfe8f-9711-4263-97e7-3ef3fb15864f");
+                mockEndpointsAndSkip(
+                    "http://localhost:8000/gemini/148dfe8f-9711-4263-97e7-3ef3fb15864f?connectionClose=true"
+                );
             }
         });
         context.start();
@@ -193,7 +201,7 @@ public class FcrepoIndexerTest extends CamelBlueprintTestSupport {
             @Override
             public void configure() throws Exception {
                 replaceFromWith("direct:start");
-                mockEndpointsAndSkip("http://localhost:8000/milliner/media/field_media_image");
+                mockEndpointsAndSkip("http://localhost:8000/milliner/media/field_media_image?connectionClose=true");
             }
         });
         context.start();

--- a/islandora-indexing-triplestore/src/main/java/ca/islandora/alpaca/indexing/triplestore/TriplestoreIndexer.java
+++ b/islandora-indexing-triplestore/src/main/java/ca/islandora/alpaca/indexing/triplestore/TriplestoreIndexer.java
@@ -59,11 +59,11 @@ public class TriplestoreIndexer extends RouteBuilder {
               .removeHeaders("*", "Authorization")
               .setHeader(Exchange.HTTP_METHOD, constant("GET"))
               .setBody(simple("${null}"))
-              .toD("${exchangeProperty.url}")
+              .toD("${exchangeProperty.url}&connectionClose=true")
               .setHeader(FCREPO_URI, simple("${exchangeProperty.url}"))
               .process(new SparqlUpdateProcessor())
               .log(INFO, LOGGER, "Indexing ${exchangeProperty.url} in triplestore")
-              .to("{{triplestore.baseUrl}}");
+              .to("{{triplestore.baseUrl}}?connectionClose=true");
 
         from("{{delete.stream}}")
             .routeId("IslandoraTriplestoreIndexerDelete")
@@ -71,7 +71,7 @@ public class TriplestoreIndexer extends RouteBuilder {
               .setHeader(FCREPO_URI, simple("${exchangeProperty.url}"))
               .process(new SparqlDeleteProcessor())
               .log(INFO, LOGGER, "Deleting ${exchangeProperty.url} in triplestore")
-              .to("{{triplestore.baseUrl}}");
+              .to("{{triplestore.baseUrl}}?connectionClose=true");
 
         // Extracts the JSONLD URL from the event message and stores it on the exchange.
         from("direct:parse.url")

--- a/islandora-indexing-triplestore/src/test/java/ca/islandora/alpaca/indexing/triplestore/TriplestoreIndexerTest.java
+++ b/islandora-indexing-triplestore/src/test/java/ca/islandora/alpaca/indexing/triplestore/TriplestoreIndexerTest.java
@@ -131,7 +131,7 @@ public class TriplestoreIndexerTest extends CamelBlueprintTestSupport {
                     replaceFromWith("direct:start");
 
                     // Rig Drupal REST endpoint to return canned jsonld
-                    interceptSendToEndpoint("http://localhost:8000/node/1?_format=jsonld")
+                    interceptSendToEndpoint("http://localhost:8000/node/1?_format=jsonld&connectionClose=true")
                             .skipSendToOriginalEndpoint()
                             .process(exchange -> {
                                 exchange.getIn().removeHeaders("*");
@@ -141,7 +141,9 @@ public class TriplestoreIndexerTest extends CamelBlueprintTestSupport {
                                         String.class);
                             });
 
-                    mockEndpointsAndSkip("http://localhost:8080/bigdata/namespace/islandora/sparql");
+                    mockEndpointsAndSkip(
+                        "http://localhost:8080/bigdata/namespace/islandora/sparql?connectionClose=true"
+                    );
                 }
         });
         context.start();
@@ -181,7 +183,7 @@ public class TriplestoreIndexerTest extends CamelBlueprintTestSupport {
             @Override
             public void configure() throws Exception {
                 replaceFromWith("direct:start");
-                mockEndpointsAndSkip("http://localhost:8080/bigdata/namespace/islandora/sparql");
+                mockEndpointsAndSkip("http://localhost:8080/bigdata/namespace/islandora/sparql?connectionClose=true");
             }
         });
         context.start();


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/978

# What does this Pull Request do?

Adds `connectionClose=true` to all the http endpoints in our camel routes.  This forces Camel to add a `Connection: close` header to all requests, terminating the connection immediately after receiving the response.

# What's new?

`connectionClose=true` all over the place as an endpoint parameter.

# How should this be tested?

- `/opt/karaf/bin/client`
- `la | grep islandora`
- Get the bundle ids for `islandora-indexing-triplestore`, `islandora-indexing-fcrepo`, and `islandora-connector-derivative`
- `bundle:stop your_id` for each of those ids
- Hit `Ctrl+D` to get out of the console
- `cd ~`
- `git clone -b connection-close https://github.com/dannylamb/Alpaca.git`
- `cd Alpaca`
- `./gradlew install`
- Then copy the jars for the three bundles we stopped into `/opt/karaf/deploy`
  - `sudo cp islandora-indexing-fcrepo/build/libs/islandora-indexing-fcrepo-0.7.1.jar /opt/karaf/deploy`
  - `sudo cp islandora-indexing-triplestore/build/libs/islandora-indexing-triplestore-0.7.1.jar /opt/karaf/deploy`
  - `sudo cp islandora-connector-derivative/build/libs/islandora-connector-derivative-0.7.1.jar /opt/karaf/deploy`

Then run your test migration that does a bunch of stuff and monitor the files karaf keeps open with lsof.

`sudo lsof | grep karaf | wc -l`

You should see it go up slightly during the migration, but maintain (and even somes drop a little) if you keep running `lsof` over and over.  When it's done, files should go back down to idle levels.

I tested this by using devel_generate to make 1000 taxonomy terms, but @seth-shaw-unlv's tiff migration seems like a good test :rocket: 

# Additional Notes:
This is it.

# Interested parties
@Islandora-CLAW/committers